### PR TITLE
patterns() deprecated since version 1.8

### DIFF
--- a/yandex_money/urls.py
+++ b/yandex_money/urls.py
@@ -5,7 +5,6 @@ from .views import NoticeFormView
 from .views import CheckOrderFormView
 
 
-urlpatterns = patterns('',
-    url(r'^aviso/', CheckOrderFormView.as_view(), name='yandex_money_aviso'),
-    url(r'^notice/', NoticeFormView.as_view(), name='yandex_money_notice'),
-)
+urlpatterns = [url(r'^check/', CheckOrderFormView.as_view(), name='yandex_money_check'),
+               url(r'^notice/', NoticeFormView.as_view(), name='yandex_money_notice')
+]


### PR DESCRIPTION
patterns() deprecated since version 1.8: urlpatterns should be a plain list of django.conf.urls.url() instances instead.
https://docs.djangoproject.com/en/1.9/ref/urls/#django.conf.urls.url